### PR TITLE
Allow line ending to be specified from sf_update

### DIFF
--- a/R/bulk-operation.R
+++ b/R/bulk-operation.R
@@ -852,6 +852,9 @@ sf_get_job_records_bulk_v2 <- function(job_id,
 #' for job completion
 #' @param max_attempts integer; defines then max number attempts to check for job 
 #' completion before stopping
+#' @param line_ending character; indicating the The line ending used for CSV job data, 
+#' marking the end of a data row. The default is NULL and determined by the operating system using
+#' "CRLF" for Windows machines and "LF" for Unix machines
 #' @template verbose
 #' @return A \code{tbl_df} of the results of the bulk job
 #' @note With Bulk 2.0 the order of records in the response is not guaranteed to 
@@ -877,8 +880,8 @@ sf_bulk_operation <- function(input_data,
                               wait_for_results = TRUE,
                               interval_seconds = 3,
                               max_attempts = 200,
-                              verbose = FALSE,
-                              line_ending = NULL){
+                              line_ending = NULL,
+                              verbose = FALSE){
 
   stopifnot(!missing(operation))
   api_type <- match.arg(api_type)

--- a/R/bulk-operation.R
+++ b/R/bulk-operation.R
@@ -159,7 +159,6 @@ sf_create_job_bulk_v2 <- function(operation = c("insert", "delete", "upsert", "u
   
   operation <- match.arg(operation)
   content_type <- match.arg(content_type)
-  line_ending <- match.arg(line_ending)
   column_delimiter <- match.arg(column_delimiter)
   if(column_delimiter != "COMMA"){
     stop("column_delimiter = 'COMMA' is currently the only supported file delimiter")
@@ -878,14 +877,15 @@ sf_bulk_operation <- function(input_data,
                               wait_for_results = TRUE,
                               interval_seconds = 3,
                               max_attempts = 200,
-                              verbose = FALSE){
+                              verbose = FALSE,
+                              line_ending = NULL){
 
   stopifnot(!missing(operation))
   api_type <- match.arg(api_type)
   
   job_info <- sf_create_job_bulk(operation, object_name=object_name, 
                                  external_id_fieldname=external_id_fieldname, 
-                                 api_type=api_type, verbose=verbose)
+                                 api_type=api_type, verbose=verbose, line_ending=line_ending)
   batches_info <- sf_create_batches_bulk(job_id = job_info$id, input_data, 
                                          api_type=api_type, verbose=verbose)
   

--- a/man/sf_bulk_operation.Rd
+++ b/man/sf_bulk_operation.Rd
@@ -8,7 +8,7 @@ sf_bulk_operation(input_data, object_name, operation = c("insert",
   "delete", "upsert", "update", "hardDelete"),
   external_id_fieldname = NULL, api_type = c("Bulk 1.0", "Bulk 2.0"),
   wait_for_results = TRUE, interval_seconds = 3, max_attempts = 200,
-  verbose = FALSE)
+  line_ending = NULL, verbose = FALSE)
 }
 \arguments{
 \item{input_data}{\code{named vector}, \code{matrix}, \code{data.frame}, or 
@@ -34,6 +34,10 @@ for job completion}
 
 \item{max_attempts}{integer; defines then max number attempts to check for job 
 completion before stopping}
+
+\item{line_ending}{character; indicating the The line ending used for CSV job data, 
+marking the end of a data row. The default is NULL and determined by the operating system using
+"CRLF" for Windows machines and "LF" for Unix machines}
 
 \item{verbose}{logical; do you want informative messages?}
 }


### PR DESCRIPTION
When I was trying to use `sf_update`, I kept getting line ending errors. I noticed it was because it was trying to infer the correct line endings to use from my OS. When I tried providing the `line_ending` argument to `sf_update`, I was getting more errors. Just made a quick edit to make sure this argument can be provided here and it flows all the way down.