### PR TITLE
Install dependencies from binary

### DIFF
--- a/.github/workflows/main-03-R-CMD-check-mac.yml
+++ b/.github/workflows/main-03-R-CMD-check-mac.yml
@@ -63,9 +63,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          # temporary hack until there's a macOS binary for ps
-          install.packages("ps", type = "source")
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type="binary")
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 

--- a/.github/workflows/main-04-R-CMD-check-windows.yml
+++ b/.github/workflows/main-04-R-CMD-check-windows.yml
@@ -63,9 +63,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          # temporary hack until there's a macOS binary for ps
-          install.packages("ps", type = "source")
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type="binary")
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 


### PR DESCRIPTION
Install dependencies from binary to avoid issues where the source is later than binary, but its installation fails which happened with the recent update to the XML package