### PR TITLE
Bump to Dev version after CRAN release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
+github: StevenMMortimer
 ko_fi: StevenMMortimer
 tidelift: cran/salesforcer

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: salesforcer
 Title: An Implementation of 'Salesforce' APIs Using Tidy Principles
-Version: 0.2.2
-Date: 2020-09-07
+Version: 0.2.2.9000
+Date: 2020-09-12
 Description: Functions connecting to the 'Salesforce' Platform APIs (REST, SOAP, 
     Bulk 1.0, Bulk 2.0, Metadata, Reports and Dashboards) 
     <https://trailhead.salesforce.com/en/content/learn/modules/api_basics/api_basics_overview>. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,20 @@
-## salesforcer 0.2.2
+## salesforcer 0.2.2.9000  
+
+### Dependencies
+
+  * None yet.
+
+### Features
+
+  * None yet.
+
+### Bug fixes
+
+  * None yet.
+
+---
+
+## salesforcer 0.2.2 [release](https://github.com/StevenMMortimer/salesforcer/releases/tag/v0.2.2)
 
 ### Dependencies
 
@@ -14,6 +30,15 @@
   ```r
   Warning: replacing previous import 'vctrs::data_frame' by 'tibble::data_frame' when loading 'dplyr'
   ```
+  
+### Features
+
+  * None 
+  
+  
+### Bug fixes
+
+  * None 
 
 ## salesforcer 0.2.1 [release](https://github.com/StevenMMortimer/salesforcer/releases/tag/v0.2.1)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@ salesforcer_state <- function(){
 #' \dontrun{
 #' get_os()
 #' }
-#' @seealso \url{https://conjugateprior.org/2015/06/identifying-the-os-from-r}
+#' @seealso \url{https://conjugateprior.org/2015/06/identifying-the-os-from-r/}
 #' @note This function is meant to be used internally. Only use when debugging.
 #' @keywords internal
 #' @export

--- a/man/get_os.Rd
+++ b/man/get_os.Rd
@@ -22,6 +22,6 @@ get_os()
 }
 }
 \seealso{
-\url{https://conjugateprior.org/2015/06/identifying-the-os-from-r}
+\url{https://conjugateprior.org/2015/06/identifying-the-os-from-r/}
 }
 \keyword{internal}


### PR DESCRIPTION
Bump to v0.2.2.9000 and the NEWS.md

Fix issue where CRAN release triggers an error for one URL that was missing a trailing slash

Add GitHub Sponsors to FUNDING.yml since account was approved